### PR TITLE
Call firestore only when authenticated

### DIFF
--- a/lib/bloc/bloc.dart
+++ b/lib/bloc/bloc.dart
@@ -5,3 +5,4 @@ export './observer.dart';
 export './raid_form/raid_form_bloc.dart';
 export './profile_editor/profile_editor_bloc.dart';
 export './comment/comment_bloc.dart';
+export './shared_events.dart';

--- a/lib/bloc/raid/raid_bloc.dart
+++ b/lib/bloc/raid/raid_bloc.dart
@@ -81,9 +81,7 @@ class RaidBloc extends Bloc<RaidEvent, RaidState> {
     if (event.data is LoggedIn) {
       _addListeners();
     } else if (event.data is SignOutLoading && state is RaidLoaded) {
-      _raidListeners.forEach((sub) async => await sub.cancel());
-      signInBloc.add(StreamClosed(raidStreamClosed: true));
-      _vikingBlocListener.cancel();
+      _cancelDataListeners();
     }
     emit(const RaidUpdating(raids: <Raid>[]));
   }
@@ -100,12 +98,17 @@ class RaidBloc extends Bloc<RaidEvent, RaidState> {
     });
   }
 
+  void _cancelDataListeners() {
+    cancelSub(StreamSubscription sub) async => await sub.cancel();
+    _raidListeners.forEach(cancelSub);
+    _vikingBlocListener.cancel();
+    signInBloc.add(RaidStreamClosed());
+  }
+
   @override
   Future<void> close() async {
     _signInBlocListener.cancel();
-    _vikingBlocListener.cancel();
-    _raidListeners.forEach((sub) async => await sub.cancel());
-    // _raidListener.cancel();
+    _cancelDataListeners();
     super.close();
   }
 }

--- a/lib/bloc/raid/raid_bloc.dart
+++ b/lib/bloc/raid/raid_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pillager/models/models.dart';
 
@@ -7,14 +9,16 @@ import 'package:pillager/bloc/bloc.dart';
 class RaidBloc extends Bloc<RaidEvent, RaidState> {
   final DatabaseService store;
   final VikingBloc vikingBloc;
+  late final StreamSubscription _blocListener;
+  late final StreamSubscription _raidListener;
 
   RaidBloc({required this.store, required this.vikingBloc})
       : super(RaidInitial()) {
-    store.raids.listen((data) {
+    _raidListener = store.raids.listen((data) {
       add(RaidDataChange(data: data));
     });
 
-    vikingBloc.stream.listen((vikingState) {
+    _blocListener = vikingBloc.stream.listen((vikingState) {
       add(RaidVikingStateChange(data: vikingState));
     });
 
@@ -70,4 +74,12 @@ class RaidBloc extends Bloc<RaidEvent, RaidState> {
   }
 
   void _onAddComment(AddComment event, Emitter emit) {}
+
+    @override
+  Future<void> close() async {
+    _blocListener.cancel();
+    _raidListener.cancel();
+    super.close();
+  }
+  
 }

--- a/lib/bloc/raid/raid_bloc.dart
+++ b/lib/bloc/raid/raid_bloc.dart
@@ -17,8 +17,11 @@ class RaidBloc extends Bloc<RaidEvent, RaidState> {
   RaidBloc(
       {required this.store, required this.vikingBloc, required this.signInBloc})
       : super(RaidInitial()) {
-    _signInBlocListener =
-        signInBloc.stream.listen((state) => add(SignInChange(state)));
+    _signInBlocListener = signInBloc.stream.listen((state) {
+      if (state is LoggedIn || state is SignOutLoading) {
+        add(SignInChange(state));
+      }
+    });
 
     _addListeners();
 
@@ -77,7 +80,7 @@ class RaidBloc extends Bloc<RaidEvent, RaidState> {
   void _onSignInChange(SignInChange event, Emitter emit) async {
     if (event.data is LoggedIn) {
       _addListeners();
-    } else if (event.data is SignOutLoading) {
+    } else if (event.data is SignOutLoading && state is RaidLoaded) {
       _raidListeners.forEach((sub) async => await sub.cancel());
       signInBloc.add(StreamClosed(raidStreamClosed: true));
       _vikingBlocListener.cancel();

--- a/lib/bloc/shared_events.dart
+++ b/lib/bloc/shared_events.dart
@@ -1,0 +1,7 @@
+import 'package:pillager/bloc/bloc.dart';
+
+class SignInChange extends VikingEvent with RaidEvent {
+  SignInState data;
+
+  SignInChange(this.data);
+}

--- a/lib/bloc/sign_in/sign_in_event.dart
+++ b/lib/bloc/sign_in/sign_in_event.dart
@@ -52,3 +52,12 @@ class UserStateChange extends SignInEvent {
 }
 
 class DeleteAccount extends SignInEvent {}
+
+class StreamClosed extends SignInEvent {
+  final bool raidStreamClosed;
+  final bool vikingStreamClosed;
+
+  StreamClosed({this.raidStreamClosed=false, this.vikingStreamClosed=false});
+
+  List<Object> get props => [raidStreamClosed, vikingStreamClosed];
+}

--- a/lib/bloc/sign_in/sign_in_event.dart
+++ b/lib/bloc/sign_in/sign_in_event.dart
@@ -53,11 +53,6 @@ class UserStateChange extends SignInEvent {
 
 class DeleteAccount extends SignInEvent {}
 
-class StreamClosed extends SignInEvent {
-  final bool raidStreamClosed;
-  final bool vikingStreamClosed;
+class RaidStreamClosed extends SignInEvent {}
 
-  StreamClosed({this.raidStreamClosed=false, this.vikingStreamClosed=false});
-
-  List<Object> get props => [raidStreamClosed, vikingStreamClosed];
-}
+class VikingStreamClosed extends SignInEvent {}

--- a/lib/bloc/sign_in/sign_in_state.dart
+++ b/lib/bloc/sign_in/sign_in_state.dart
@@ -15,7 +15,7 @@ class SignOutLoading extends SignInState {
   final bool vikingStreamClosed;
 
   SignOutLoading(
-      {required this.raidStreamClosed, required this.vikingStreamClosed});
+      {this.raidStreamClosed=false, this.vikingStreamClosed=false});
 
   @override
   List<Object> get props => [raidStreamClosed, vikingStreamClosed];

--- a/lib/bloc/sign_in/sign_in_state.dart
+++ b/lib/bloc/sign_in/sign_in_state.dart
@@ -10,7 +10,16 @@ class SignInInitial extends SignInState {}
 
 class SignInLoading extends SignInState {}
 
-class SignOutLoading extends SignInState {}
+class SignOutLoading extends SignInState {
+  final bool raidStreamClosed;
+  final bool vikingStreamClosed;
+
+  SignOutLoading(
+      {required this.raidStreamClosed, required this.vikingStreamClosed});
+
+  @override
+  List<Object> get props => [raidStreamClosed, vikingStreamClosed];
+}
 
 class LoggedIn extends SignInState {
   final User user;

--- a/lib/bloc/viking/viking_bloc.dart
+++ b/lib/bloc/viking/viking_bloc.dart
@@ -17,8 +17,11 @@ class VikingBloc extends Bloc<VikingEvent, VikingState> {
     final _vikingListener =
         store.vikings.listen((data) => add(VikingDataChange(data)));
     _vikingListeners.add(_vikingListener);
-    _signInListener =
-        signInBloc.stream.listen((state) => add(SignInChange(state)));
+    _signInListener = signInBloc.stream.listen((state) {
+      if (state is LoggedIn || state is SignOutLoading) {
+        add(SignInChange(state));
+      }
+    });
 
     on<VikingDataChange>(_onVikingDataChange);
     on<UpdateViking>(_onUpdateViking);
@@ -41,7 +44,7 @@ class VikingBloc extends Bloc<VikingEvent, VikingState> {
       final _vikingListener =
           store.vikings.listen((data) => add(VikingDataChange(data)));
       _vikingListeners.add(_vikingListener);
-    } else if (event.data is SignOutLoading) {
+    } else if (event.data is SignOutLoading && state is VikingLoaded) {
       _vikingListeners.forEach((sub) async {
         await sub.cancel();
       });

--- a/lib/bloc/viking/viking_bloc.dart
+++ b/lib/bloc/viking/viking_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:pillager/services/services.dart';
@@ -6,14 +8,14 @@ import 'package:pillager/bloc/bloc.dart';
 class VikingBloc extends Bloc<VikingEvent, VikingState> {
   final DatabaseService store;
   final SignInBloc signInBloc;
+  late final StreamSubscription _vikingListener;
 
   VikingBloc({required this.store, required this.signInBloc})
       : super(VikingInitial()) {
-    signInBloc.stream.listen((signInState) => add(SignInChange(signInState)));
+    _vikingListener = store.vikings.listen((data) => add(VikingDataChange(data)));
 
     on<VikingDataChange>(_onVikingDataChange);
     on<UpdateViking>(_onUpdateViking);
-    on<SignInChange>(_onSignInChange);
   } 
 
   void _onVikingDataChange(VikingDataChange event, Emitter emit) {
@@ -28,10 +30,10 @@ class VikingBloc extends Bloc<VikingEvent, VikingState> {
     }
   }
 
-    void _onSignInChange(SignInChange event, Emitter emit) {
-      if (event.data is LoggedIn) {
-        // Subscribe to the stream of vikings data
-        // Using auth token?
-      }
+  @override
+  Future<void> close() async {
+    _vikingListener.cancel();
+    super.close();
   }
+
 }

--- a/lib/bloc/viking/viking_bloc.dart
+++ b/lib/bloc/viking/viking_bloc.dart
@@ -9,12 +9,12 @@ class VikingBloc extends Bloc<VikingEvent, VikingState> {
 
   VikingBloc({required this.store, required this.signInBloc})
       : super(VikingInitial()) {
-    // signInBloc.stream.listen((signInState) => add(SignInChange(signInState)));
-    store.vikings.listen((data) => add(VikingDataChange(data)));
+    signInBloc.stream.listen((signInState) => add(SignInChange(signInState)));
 
     on<VikingDataChange>(_onVikingDataChange);
     on<UpdateViking>(_onUpdateViking);
-  }
+    on<SignInChange>(_onSignInChange);
+  } 
 
   void _onVikingDataChange(VikingDataChange event, Emitter emit) {
     emit(VikingLoaded(vikings: event.data));
@@ -26,5 +26,12 @@ class VikingBloc extends Bloc<VikingEvent, VikingState> {
     store.updateViking(event.viking, event.update);
     emit(VikingUpdating(vikings: state.vikings));
     }
+  }
+
+    void _onSignInChange(SignInChange event, Emitter emit) {
+      if (event.data is LoggedIn) {
+        // Subscribe to the stream of vikings data
+        // Using auth token?
+      }
   }
 }

--- a/lib/bloc/viking/viking_bloc.dart
+++ b/lib/bloc/viking/viking_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pillager/models/models.dart';
 
 import 'package:pillager/services/services.dart';
 import 'package:pillager/bloc/bloc.dart';
@@ -8,32 +9,53 @@ import 'package:pillager/bloc/bloc.dart';
 class VikingBloc extends Bloc<VikingEvent, VikingState> {
   final DatabaseService store;
   final SignInBloc signInBloc;
-  late final StreamSubscription _vikingListener;
+  late final StreamSubscription _signInListener;
+  final List<StreamSubscription> _vikingListeners = <StreamSubscription>[];
 
   VikingBloc({required this.store, required this.signInBloc})
       : super(VikingInitial()) {
-    _vikingListener = store.vikings.listen((data) => add(VikingDataChange(data)));
+    final _vikingListener =
+        store.vikings.listen((data) => add(VikingDataChange(data)));
+    _vikingListeners.add(_vikingListener);
+    _signInListener =
+        signInBloc.stream.listen((state) => add(SignInChange(state)));
 
     on<VikingDataChange>(_onVikingDataChange);
     on<UpdateViking>(_onUpdateViking);
-  } 
+    on<SignInChange>(_onSignInChange);
+  }
 
   void _onVikingDataChange(VikingDataChange event, Emitter emit) {
     emit(VikingLoaded(vikings: event.data));
   }
 
   void _onUpdateViking(UpdateViking event, Emitter emit) {
-    if (event.update.isNotEmpty)
-    {
-    store.updateViking(event.viking, event.update);
-    emit(VikingUpdating(vikings: state.vikings));
+    if (event.update.isNotEmpty) {
+      store.updateViking(event.viking, event.update);
+      emit(VikingUpdating(vikings: state.vikings));
     }
+  }
+
+  void _onSignInChange(SignInChange event, Emitter emit) async {
+    if (event.data is LoggedIn) {
+      final _vikingListener =
+          store.vikings.listen((data) => add(VikingDataChange(data)));
+      _vikingListeners.add(_vikingListener);
+    } else if (event.data is SignOutLoading) {
+      _vikingListeners.forEach((sub) async {
+        await sub.cancel();
+      });
+      signInBloc.add(StreamClosed(vikingStreamClosed: true));
+    }
+    emit(const VikingUpdating(vikings: <String, Viking>{}));
   }
 
   @override
   Future<void> close() async {
-    _vikingListener.cancel();
+    _signInListener.cancel();
+    _vikingListeners.forEach((sub) {
+      sub.cancel();
+    });
     super.close();
   }
-
 }

--- a/lib/bloc/viking/viking_bloc.dart
+++ b/lib/bloc/viking/viking_bloc.dart
@@ -41,16 +41,23 @@ class VikingBloc extends Bloc<VikingEvent, VikingState> {
 
   void _onSignInChange(SignInChange event, Emitter emit) async {
     if (event.data is LoggedIn) {
-      final _vikingListener =
-          store.vikings.listen((data) => add(VikingDataChange(data)));
-      _vikingListeners.add(_vikingListener);
+      _addDataListeners();
     } else if (event.data is SignOutLoading && state is VikingLoaded) {
-      _vikingListeners.forEach((sub) async {
-        await sub.cancel();
-      });
-      signInBloc.add(StreamClosed(vikingStreamClosed: true));
+      _cancelDataListeners();
     }
     emit(const VikingUpdating(vikings: <String, Viking>{}));
+  }
+
+  void _addDataListeners() {
+    final StreamSubscription _vikingListener =
+        store.vikings.listen((data) => add(VikingDataChange(data)));
+    _vikingListeners.add(_vikingListener);
+  }
+
+  void _cancelDataListeners() {
+    cancelSub(StreamSubscription sub) async => await sub.cancel();
+    _vikingListeners.forEach(cancelSub);
+    signInBloc.add(VikingStreamClosed());
   }
 
   @override

--- a/lib/bloc/viking/viking_event.dart
+++ b/lib/bloc/viking/viking_event.dart
@@ -1,13 +1,6 @@
-import 'package:pillager/bloc/bloc.dart';
 import 'package:pillager/models/models.dart';
 
 abstract class VikingEvent {}
-
-class SignInChange extends VikingEvent {
-  SignInState data;
-
-  SignInChange(this.data);
-}
 
 class VikingDataChange extends VikingEvent {
   Map<String, Viking> data;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ void main() async {
           BlocProvider(
             create: (context) => RaidBloc(
               store: DatabaseService(),
+              signInBloc: context.read<SignInBloc>(),
               vikingBloc: context.read<VikingBloc>(),
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,6 @@ void main() async {
               store: DatabaseService(),
               signInBloc: context.read<SignInBloc>(),
             ),
-            lazy:false,
           ),
           BlocProvider(
             create: (context) => RaidBloc(

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pillager/models/models.dart';
 
 class DatabaseService {


### PR DESCRIPTION
Firestore security rules now require a valid auth token to access any collection. Thus, any calls and or subscriptions to snapshots() streams must be opened after sign in and closed before sign out. Otherwise we will get errors.

With this update, the blocs dealing with firestore data (RaidBloc, VikingBloc) will listen for changes in SignInBloc state. On LoggedIn, they add the necessary listeners. On SignOutLoading, they cancel all firestore listeners.

The SignInBloc must not log out until the all firestore streamsubscriptions have been canceled. So it will wait for two events: RaidStreamClosed, and VikingStreamClosed. Then it sends the sign out request to firebase auth.

NOTE: since the data blocs are lazily initialized, this sequence of events does not begin until the user signs in.